### PR TITLE
Improves html validity

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -52,9 +52,9 @@
 
 </head>
 
-{{ include('partials/header.html.twig') }}
-
 <body class="bg-very-dark-grey-primary text-white">
+
+{{ include('partials/header.html.twig') }}
 
 {% block body %}{% endblock %}
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -36,8 +36,6 @@
           as="style">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
           rel="stylesheet">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@200..800&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Spline+Sans+Mono:ital,wght@0,300..700;1,300..700&display=swap"
           rel="stylesheet">


### PR DESCRIPTION
Remove duplicated meta headers

<img width="770" alt="Capture d’écran 2025-05-24 à 14 50 20" src="https://github.com/user-attachments/assets/8df29108-f7f4-46e6-b20a-779f87dafa87" />


Reorder HTML tags to improve validity.

<img width="910" alt="Capture d’écran 2025-05-24 à 14 50 12" src="https://github.com/user-attachments/assets/c03e2104-33a9-4fde-ae98-7ad6a5b190bc" />
